### PR TITLE
feat: add handling for incomplete tasks

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -80,6 +80,10 @@ class UserProfile(models.Model):
     bio = models.TextField(default="")
 
 class Sprint(PersistedObject):
+    class IncompleteTaskBehavior(models.TextChoices):
+        COMPLETE_TASKS = "complete", "Complete Tasks"
+        MOVE_TO_BACKLOG = "backlog", "Move to Backlog"
+
     name = models.CharField(max_length=200)
     start_date = models.DateField()
     end_date = models.DateField()

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -134,6 +134,11 @@ class ProjectSerializer(PersistedObjectSerializer):
     
 class SprintSerializer(PersistedObjectSerializer):
     project = serializers.PrimaryKeyRelatedField(read_only=True)
+    on_incomplete_tasks = serializers.ChoiceField(
+        choices=Sprint.IncompleteTaskBehavior.choices,
+        required=False,
+        allow_null=True
+    )
     
     class Meta:
         model = Sprint
@@ -143,7 +148,8 @@ class SprintSerializer(PersistedObjectSerializer):
             "start_date",
             "end_date",
             "project",
-            "completed"
+            "completed",
+            "on_incomplete_tasks"
         ]
 
         read_only_fields = [

--- a/backend/api/tests/sprints/test_complete.py
+++ b/backend/api/tests/sprints/test_complete.py
@@ -4,7 +4,7 @@ from api.models import Project, Sprint, Task
 from datetime import date, timedelta
 
 
-class SprintDeleteTests(AuthenticatedAPITestCase):
+class SprintCompleteTests(AuthenticatedAPITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.create_user()
@@ -30,46 +30,42 @@ class SprintDeleteTests(AuthenticatedAPITestCase):
                                                     modified_by=self.user)
 
     @tag("sprint")
-    def test_delete_sprint_returns_204(self):
-        response = self.client.delete(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/?on_incomplete_tasks=complete")
-        self.assertEqual(response.status_code, 204)
-
-    @tag("sprint")
-    def test_deleted_sprint_is_absent(self):
-        self.client.delete(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/?on_incomplete_tasks=complete")
-        self.assertEqual(Sprint.objects.filter(id=self.sprint.id).count(), 0)
-    
-    @tag("sprint")
-    def test_completing_tasks_in_deleted_sprint(self):
-        self.client.delete(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/?on_incomplete_tasks=complete")
+    def test_completing_tasks_in_completed_sprint(self):
+        sprint_data = self.client.get(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/").data
+        sprint_data["completed"] = True
+        sprint_data["on_incomplete_tasks"] = "complete"
+        self.client.put(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/", sprint_data, format="json")
         
         # Confirm that no tasks were deleted
         self.assertEqual(Task.objects.count(), 4)
 
-        # Confirm that the tasks were completed and removed from the sprint
-        self.assertEqual(len(Task.objects.filter(sprint__id=self.sprint.id)), 0)
+        # Confirm that the tasks were completed
+        self.assertEqual(len(Task.objects.filter(sprint__id=self.sprint.id)), 3)
         sprint_task_one = Task.objects.get(id=self.sprint_task_one.id)
         self.assertEqual(sprint_task_one.completed, True)
-        self.assertEqual(sprint_task_one.sprint, None)
+        self.assertEqual(sprint_task_one.sprint.id, self.sprint.id)
         self.assertEqual(sprint_task_one.status, Task.Status.DONE)
         sprint_task_two = Task.objects.get(id=self.sprint_task_two.id)
         self.assertEqual(sprint_task_two.completed, True)
-        self.assertEqual(sprint_task_two.sprint, None)
+        self.assertEqual(sprint_task_two.sprint.id, self.sprint.id)
         self.assertEqual(sprint_task_two.status, Task.Status.DONE)
 
-        # Confirm that the existing completed task is removed from the sprint
+        # Confirm that the existing completed task is not removed from the sprint
         completed_sprint_task = Task.objects.get(id=self.completed_sprint_task.id)
-        self.assertEqual(completed_sprint_task.sprint, None)
+        self.assertEqual(completed_sprint_task.sprint.id, self.sprint.id)
     
     @tag("sprint")
-    def test_backlogging_tasks_in_deleted_sprint(self):
-        self.client.delete(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/?on_incomplete_tasks=backlog")
+    def test_backlogging_tasks_in_completed_sprint(self):
+        sprint_data = self.client.get(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/").data
+        sprint_data["completed"] = True
+        sprint_data["on_incomplete_tasks"] = "backlog"
+        self.client.put(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/", sprint_data, format="json")
         
         # Confirm that no tasks were deleted
         self.assertEqual(Task.objects.count(), 4)
 
         # Confirm that the tasks were not completed but were removed from the sprint
-        self.assertEqual(len(Task.objects.filter(sprint__id=self.sprint.id)), 0)
+        self.assertEqual(len(Task.objects.filter(sprint__id=self.sprint.id)), 1)
         sprint_task_one = Task.objects.get(id=self.sprint_task_one.id)
         self.assertEqual(sprint_task_one.completed, False)
         self.assertEqual(sprint_task_one.sprint, None)
@@ -79,6 +75,6 @@ class SprintDeleteTests(AuthenticatedAPITestCase):
         self.assertEqual(sprint_task_two.sprint, None)
         self.assertEqual(sprint_task_two.status, Task.Status.IN_PROGRESS)
 
-        # Confirm that the existing completed task is removed from the sprint
+        # Confirm that the existing completed task is not removed from the sprint
         completed_sprint_task = Task.objects.get(id=self.completed_sprint_task.id)
-        self.assertEqual(completed_sprint_task.sprint, None)
+        self.assertEqual(completed_sprint_task.sprint.id, self.sprint.id)

--- a/backend/api/tests/sprints/test_update.py
+++ b/backend/api/tests/sprints/test_update.py
@@ -19,15 +19,16 @@ class SprintUpdateTests(AuthenticatedAPITestCase):
     @tag("sprint")
     def test_update_sprint_returns_200(self):
         sprint = self.client.get(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/").data
-        sprint["completed"] = True
+        sprint["start_date"] = str(date.today() + timedelta(days=1))
         response = self.client.put(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/", sprint, format="json")
         self.assertEqual(response.status_code, 200)
 
     @tag("sprint")
     def test_update_sprint_persists(self):
         sprint = self.client.get(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/").data
-        sprint["completed"] = True
+        updated_date = date.today() + timedelta(days=1)
+        sprint["start_date"] = str(updated_date)
         self.client.put(f"/api/projects/{self.project.id}/sprints/{self.sprint.id}/", sprint, format="json")
 
         updated_sprint = Sprint.objects.get(id=self.sprint.id)
-        self.assertEqual(updated_sprint.completed, True)
+        self.assertEqual(updated_sprint.start_date, updated_date)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 import logging
 from rest_framework import generics, status
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -239,6 +240,25 @@ class SprintView(generics.RetrieveUpdateDestroyAPIView):
 
     def perform_update(self, serializer):
         serializer.save(modified_by=self.request.user)
+    
+    def perform_destroy(self, serializer):
+        sprint_id=self.kwargs.get("pk")
+        request=self.get_serializer_context()["request"]
+        try:
+            task_incomplete_behavior_param = request.query_params["on_incomplete_tasks"]
+            task_incomplete_behavior = Sprint.IncompleteTaskBehavior(task_incomplete_behavior_param)
+        except Exception:
+            raise ValidationError("A valid behavior for incomplete tasks must be specified")
+
+        incomplete_tasks=Task.objects.filter(sprint__id=sprint_id,completed=False)
+        if task_incomplete_behavior == str(Sprint.IncompleteTaskBehavior.COMPLETE_TASKS):
+            # Mark all tasks as complete
+            incomplete_tasks.update(completed=True)
+        elif task_incomplete_behavior == str(Sprint.IncompleteTaskBehavior.MOVE_TO_BACKLOG):
+            # Move all incomplete tasks to backlog
+            incomplete_tasks.update(sprint=None)
+
+        serializer.delete()
 
 class SprintTaskListView(generics.ListAPIView):
     serializer_class = TaskSerializer

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -237,27 +237,47 @@ class SprintView(generics.RetrieveUpdateDestroyAPIView):
             project__users=self.request.user,
             is_deleted=False
         ).distinct()
+    
+    def handle_incomplete_tasks(self, sprint_id: str, task_incomplete_behavior: Sprint.IncompleteTaskBehavior):
+        """Handles incomplete tasks when a sprint is closed or completed"""
+        incomplete_tasks=Task.objects.filter(sprint__id=sprint_id,completed=False)
+        if task_incomplete_behavior == str(Sprint.IncompleteTaskBehavior.COMPLETE_TASKS):
+            # Mark all tasks as complete
+            incomplete_tasks.update(completed=True,status=Task.Status.DONE)
+        elif task_incomplete_behavior == str(Sprint.IncompleteTaskBehavior.MOVE_TO_BACKLOG):
+            # Move all incomplete tasks to backlog
+            incomplete_tasks.update(sprint=None)
 
     def perform_update(self, serializer):
+        sprint_id=self.kwargs.get("pk")
+        sprint = Sprint.objects.get(id=sprint_id)
+
+        # If we're setting the sprint to completed, we need the completion behavior
+        if sprint.completed == False and serializer.validated_data["completed"] == True:
+            try:
+                # Get the incomplete task behavior parameter
+                task_incomplete_behavior_param = serializer.validated_data["on_incomplete_tasks"]
+                task_incomplete_behavior = Sprint.IncompleteTaskBehavior(task_incomplete_behavior_param)
+            except Exception:
+                raise ValidationError("A valid behavior for incomplete tasks must be specified")
+            
+            self.handle_incomplete_tasks(sprint_id=sprint_id, task_incomplete_behavior=task_incomplete_behavior)
+        
+        # Set modified by
         serializer.save(modified_by=self.request.user)
     
     def perform_destroy(self, serializer):
         sprint_id=self.kwargs.get("pk")
-        request=self.get_serializer_context()["request"]
+
         try:
+            # Get the incomplete task behavior parameter
+            request=self.get_serializer_context()["request"]
             task_incomplete_behavior_param = request.query_params["on_incomplete_tasks"]
             task_incomplete_behavior = Sprint.IncompleteTaskBehavior(task_incomplete_behavior_param)
         except Exception:
             raise ValidationError("A valid behavior for incomplete tasks must be specified")
 
-        incomplete_tasks=Task.objects.filter(sprint__id=sprint_id,completed=False)
-        if task_incomplete_behavior == str(Sprint.IncompleteTaskBehavior.COMPLETE_TASKS):
-            # Mark all tasks as complete
-            incomplete_tasks.update(completed=True)
-        elif task_incomplete_behavior == str(Sprint.IncompleteTaskBehavior.MOVE_TO_BACKLOG):
-            # Move all incomplete tasks to backlog
-            incomplete_tasks.update(sprint=None)
-
+        self.handle_incomplete_tasks(sprint_id=sprint_id, task_incomplete_behavior=task_incomplete_behavior)
         serializer.delete()
 
 class SprintTaskListView(generics.ListAPIView):


### PR DESCRIPTION
This adds handling for tasks which are incomplete when a sprint is completed or deleted. There are currently two options:

- Move the tasks to the backlog
- Mark the tasks as completed

For sprint completion, this is an extra attribute on the `PUT/PATCH` request. For sprint deletion, since the request does not have a body, it gets added as a query parameter (i.e. `DELETE /api/projects/<id>/sprints/<id>/?on_incomplete_tasks=backlog`).

Completes #140 and #144 